### PR TITLE
Fix early loading skipping dual Hijacker/Loader plugins

### DIFF
--- a/src/main/java/zone/rong/mixinbooter/MixinBooterPlugin.java
+++ b/src/main/java/zone/rong/mixinbooter/MixinBooterPlugin.java
@@ -84,7 +84,7 @@ public final class MixinBooterPlugin implements IFMLLoadingPlugin {
                         FermiumRegistryAPI.removeMixin(hijacked);
                     }
                 }
-                else if (theMod instanceof IEarlyMixinLoader) {
+                if (theMod instanceof IEarlyMixinLoader) {
                     IEarlyMixinLoader earlyMixinLoader = (IEarlyMixinLoader) theMod;
                     for (String mixinConfig : earlyMixinLoader.getMixinConfigs()) {
                         if (earlyMixinLoader.shouldMixinConfigQueue(context)) {


### PR DESCRIPTION
Fixes plugins implementing both Hijacker and EarlyMixinLoader having the early loaded mixins skipped.
This can be tested with Alfheim Lighting Engine.
Have not tested any further loading issues.